### PR TITLE
Option 'maxlen-guessable-test': disable environment&common test for long passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ if($sp->validate($PasswordToTest) === false) {
 
 Possible options:
 * 'disable' (array): disable stated tests, e.g. array('special', 'lower') to disable both the test for special and lowercase characters.
+* 'maxlen-guessable-test' (integer): disable environment and common password checks for passwords longer than given integer (due to high memory usage and cpu usage). Default: 24.
 
 ## Test
 Here's some test:

--- a/php/StupidPass.php
+++ b/php/StupidPass.php
@@ -51,6 +51,8 @@ class StupidPass
 		$this->options = $options;
 		if(!array_key_exists("disable", $this->options))
 		  $this->options['disable'] = array();
+		if(!array_key_exists("maxlen-guessable-test", $this->options))
+		  $this->options['maxlen-guessable-test'] = 24;
 
 		$this->maxlen = $maxlen;
 		$this->environ = $environ;
@@ -80,12 +82,15 @@ class StupidPass
 		if(!in_array('onlynumeric', $this->options['disable']))
 		  $this->onlynumeric();
 
-		$this->extrapolate();
+                if (strlen($pass) <= $this->options['maxlen-guessable-test']) {
+                  $this->extrapolate();
 
-		if(!in_array('environ', $this->options['disable']))
-		  $this->environmental();
-		if(!in_array('common', $this->options['disable']))
-		  $this->common();
+                  if(!in_array('environ', $this->options['disable']))
+                    $this->environmental();
+                  if(!in_array('common', $this->options['disable']))
+                    $this->common();
+                }
+
 		$this->pass = null;
 		return (empty($this->errors));
 	}

--- a/php/tests/test.php
+++ b/php/tests/test.php
@@ -10,7 +10,8 @@ $list = array(
 'P@55W0r6',
 'zxcasdqwe',
 'zxc45dqw3',
-'aPf1#@_GHe'
+'aPf1#@_GHe',
+'437818ec5af53a3ba6e5cb9435fe177fALKO',
 );
 
 $sp = new StupidPass();


### PR DESCRIPTION
I had the problem that the check for a very long password failed due to high memory usage. Even with higher memory setting, the test took very long (>1min). Therefore I added the option 'maxlen-guessable-test' which will disable the environment and the common test for long passwords.

Maybe you have a better idea for the option name?